### PR TITLE
Add ext $ref for GeoJSON / DataPackage schemas

### DIFF
--- a/api/schemas.py
+++ b/api/schemas.py
@@ -6,6 +6,26 @@ from typing import List, Optional
 
 from pydantic import BaseModel, validator
 
+class GeoJSON(BaseModel):
+    """Reference to the external GeoJSON JSON Schema"""
+    __root__: dict
+
+    class Config:
+        @staticmethod
+        def schema_extra(schema: dict):
+            schema.clear()
+            schema["$ref"] = "https://geojson.org/schema/GeoJSON.json"
+
+class DataPackage(BaseModel):
+    """Reference to the external DataPackage JSON Schema"""
+    __root__: dict
+
+    class Config:
+        @staticmethod
+        def schema_extra(schema: dict):
+            schema.clear()
+            schema["$ref"] = "https://specs.frictionlessdata.io/schemas/data-package.json"
+
 class BoundarySummary(BaseModel):
     """Summary of a boundary"""
     id=int
@@ -18,8 +38,8 @@ class BoundarySummary(BaseModel):
 class Boundary(BoundarySummary):
     """Complete boundary information"""
     admin_level:str
-    geometry:dict # GeoJSON
-    envelope:dict # GeoJSON
+    geometry:GeoJSON
+    envelope:GeoJSON
 
     class Config:
         orm_mode = True
@@ -55,7 +75,7 @@ class Package(PackageSummary):
     """Detailed information about a package"""
     boundary: Boundary # Boundary from-which the package has been created
     processors: List[Processor] # Datasets within this package
-    datapackage: dict # Datapackage.json parsed from the FS and nested within the Package response
+    datapackage: DataPackage # Datapackage.json parsed from the FS and nested within the Package response
 
 # Jobs
 


### PR DESCRIPTION
Added simple models for `GeoJSON` and `DataPackage` that are still treated like a `dict` but will be represented in the OpenAPI schema as simply pointing with `$ref` to an external schema, for example:

```
  "DataPackage": {
      "$ref": "https://specs.frictionlessdata.io/schemas/data-package.json"
  },
  "GeoJSON": {
      "$ref": "https://geojson.org/schema/GeoJSON.json"
  },
```

The main benefit of this is that client auto-generation (at least the TypeScript one we're using) will pick up the external schemas and use them to generate proper types for these for use in the frontend, without the need to actually write all the pydantic models.

For the GeoJSON types, an alternative would be to use a library like https://github.com/developmentseed/geojson-pydantic but that seems potentially unnecessary, unless we'd actually want to validate that the objects coming from the database are, for example, the geometry type we expect them to be.