### PR TITLE
Fix Boundary geometry/envelope schema

### DIFF
--- a/api/schemas.py
+++ b/api/schemas.py
@@ -7,8 +7,8 @@ from typing import List, Optional
 from pydantic import BaseModel, validator
 
 
-class GeoJSON(BaseModel):
-    """Reference to the external GeoJSON JSON Schema"""
+class Polygon(BaseModel):
+    """Reference to the external GeoJSON Polygon JSON Schema"""
 
     __root__: dict
 
@@ -16,7 +16,19 @@ class GeoJSON(BaseModel):
         @staticmethod
         def schema_extra(schema: dict):
             schema.clear()
-            schema["$ref"] = "https://geojson.org/schema/GeoJSON.json"
+            schema["$ref"] = "https://geojson.org/schema/Polygon.json"
+
+
+class MultiPolygon(BaseModel):
+    """Reference to the external GeoJSON MultiPolygon JSON Schema"""
+
+    __root__: dict
+
+    class Config:
+        @staticmethod
+        def schema_extra(schema: dict):
+            schema.clear()
+            schema["$ref"] = "https://geojson.org/schema/MultiPolygon.json"
 
 
 class DataPackage(BaseModel):
@@ -48,8 +60,8 @@ class Boundary(BoundarySummary):
     """Complete boundary information"""
 
     admin_level: str
-    geometry: GeoJSON
-    envelope: GeoJSON
+    geometry: MultiPolygon
+    envelope: Polygon
 
     class Config:
         orm_mode = True


### PR DESCRIPTION
The previous typing for `GeoJSON` was incorrect as the `geometry` and `envelope` fields of the `Boundary` schema are actually instances of GeoJSON `Geometry` rather than full features.

Changing to a single `Geometry` schema would obscure information about geometry type so we can set the schemas to `MultiPolygon` and `Polygon`.